### PR TITLE
Add startup logs to react

### DIFF
--- a/react/Dockerfile
+++ b/react/Dockerfile
@@ -3,4 +3,7 @@
 
 FROM node:10.7-alpine
 WORKDIR /root/
-CMD npm install && npm start
+CMD echo "getting latest npm modules" \
+    && npm install \
+    && echo "installation complete, starting" \
+    && npm start


### PR DESCRIPTION
Possible solution to https://github.com/karlkeefer/pngr/issues/17 .

I thought the app was broken when I first started it, as the `docker-compose logs` don't indicate anything is still happening in the react app until after a long (> 1 minute) NPM install process finishes.

Another alternative would be to `npm install --loglevel info`.