### PR TITLE
reduce image size

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,6 +1,7 @@
 FROM postgres:12.1
 
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install -y wget \
+    && rm -rf /var/lib/apt/lists/*
 
 # snag a binary of golang-migrate
 RUN wget -nv https://github.com/golang-migrate/migrate/releases/download/v4.13.0/migrate.linux-amd64.tar.gz \ 


### PR DESCRIPTION
Hello
just a minor optimization, as the [Docker  Document](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) says, `when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. `

so I add this line into the Dockerfile to reduce the image size

could it really reduce the image size?

my company network environment is not good. When I get off work, I will prove it, wait a minute!