### PR TITLE
Bump react router

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -22,7 +22,7 @@
         "react-cookie": "^3.1.2",
         "react-dom": "^16.14.0",
         "react-helmet": "^6.1.0",
-        "react-router-dom": "^5.2.1",
+        "react-router-dom": "^6.8.1",
         "react-scripts": "^5.0.1",
         "sanitize.css": "^13.0.0",
         "semantic-ui-react": "2.1.3",
@@ -2853,6 +2853,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -6351,29 +6359,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/history/node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
-    "node_modules/history/node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -11772,58 +11757,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.3.2"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-scripts": {
       "version": "5.0.1",
@@ -20728,16 +20689,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -23976,6 +23927,11 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
+    "@remix-run/router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
+      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA=="
+    },
     "@rushstack/eslint-patch": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
@@ -26484,31 +26440,6 @@
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "requires": {
         "has-symbols": "^1.0.2"
-      }
-    },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      },
-      "dependencies": {
-        "resolve-pathname": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-          "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-        },
-        "value-equal": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-          "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
-        }
       }
     },
     "hoist-non-react-statics": {
@@ -30638,53 +30569,20 @@
       }
     },
     "react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
+      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "@remix-run/router": "1.3.2"
       }
     },
     "react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
+      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.3.2",
+        "react-router": "6.8.1"
       }
     },
     "react-scripts": {
@@ -37054,16 +36952,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
-    },
-    "tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/react/package.json
+++ b/react/package.json
@@ -17,7 +17,7 @@
     "react-cookie": "^3.1.2",
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",
-    "react-router-dom": "^5.2.1",
+    "react-router-dom": "^6.8.1",
     "react-scripts": "^5.0.1",
     "sanitize.css": "^13.0.0",
     "semantic-ui-react": "2.1.3",

--- a/react/src/Nav/Nav.tsx
+++ b/react/src/Nav/Nav.tsx
@@ -1,21 +1,13 @@
 import { useContext, useEffect, useState } from 'react'
 
 import { useLocation } from 'react-router'
-import { NavLink, NavLinkProps } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import { Button, Container, Menu } from 'semantic-ui-react'
 
 import { Anon, LoggedIn } from 'Shared/Roles'
 import { UserContainer } from 'Shared/UserContainer'
 
 import './responsive.css'
-
-// helper for semanticUI + react-router
-const MenuLink = (props: NavLinkProps) => (
-  <NavLink
-    {...props}
-    activeClassName="active"
-  />
-);
 
 const Nav = () => {
   const location = useLocation();
@@ -32,15 +24,15 @@ const Nav = () => {
     <Container>
       <Button id="toggler" fluid color='black' icon='sidebar' onClick={() => setOpen(!open)} />
       <Menu.Menu className={menuClass} position="left" id="override">
-        <Menu.Item as={MenuLink} exact to="/" name="Home" />
+        <Menu.Item as={NavLink} to="/" name="Home" />
         <LoggedIn>
-          <Menu.Item as={MenuLink} to="/posts" name="Posts" />
+          <Menu.Item as={NavLink} to="/posts" name="Posts" />
         </LoggedIn>
       </Menu.Menu>
       <Menu.Menu className={menuClass} position="right">
         <Anon>
-          <Menu.Item as={MenuLink} exact to={{ pathname: "/login", state: { from: location } }} name="Log In" />
-          <Menu.Item as={MenuLink} exact to="/signup" name="Sign Up" />
+          <Menu.Item as={NavLink} to={{ pathname: "/login", state: { from: location } }} name="Log In" />
+          <Menu.Item as={NavLink} to="/signup" name="Sign Up" />
         </Anon>
         <LoggedIn>
           <Menu.Item link={true} onClick={handleLogout} content="Log Out" />

--- a/react/src/Routes/Helpers.tsx
+++ b/react/src/Routes/Helpers.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useContext } from "react";
 
-import { Redirect } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { Loader, Container, Dimmer } from "semantic-ui-react";
 
 import SimplePage from "Shared/SimplePage";
@@ -20,7 +20,7 @@ export function RequireAuth({ children, redirectTo }: RequireAuthProps) {
   }
 
   if (!user.id) {
-    return <Redirect to={redirectTo} />;
+    return <Navigate to={redirectTo} replace />;
   }
 
   return <>{children}</>

--- a/react/src/Routes/Helpers.tsx
+++ b/react/src/Routes/Helpers.tsx
@@ -1,31 +1,29 @@
-import React, { useContext } from 'react'
+import { ReactNode, useContext } from "react";
 
-import { Redirect, RouteProps } from 'react-router'
-import { Route } from 'react-router-dom'
-import { Loader, Container, Dimmer } from 'semantic-ui-react'
+import { Redirect } from "react-router-dom";
+import { Loader, Container, Dimmer } from "semantic-ui-react";
 
-import SimplePage from 'Shared/SimplePage'
-import { UserContainer } from 'Shared/UserContainer'
+import SimplePage from "Shared/SimplePage";
+import { UserContainer } from "Shared/UserContainer";
+
+type RequireAuthProps = {
+  children: ReactNode;
+  redirectTo: string;
+};
 
 // check the user is logged in, and redirect to login screen if still not auth'd
+export function RequireAuth({ children, redirectTo }: RequireAuthProps) {
+  const { user, userLoading } = useContext(UserContainer);
 
-export const PrivateRoute = ({ component, location, ...rest }: RouteProps ) => {
-  const { user, userLoading } = useContext(UserContainer)
-  const C = component as React.FC
+  if (userLoading) {
+    return <BigLoader />;
+  }
 
-  return (
-    <Route {...rest} render={(props) => {
-      if (userLoading) {
-        return <BigLoader />
-      }
+  if (!user.id) {
+    return <Redirect to={redirectTo} />;
+  }
 
-      if (!user.id) {
-        return <Redirect to={{ pathname: '/login', state: { from: location } }} />
-      }
-
-      return <C />
-    }} />
-  );
+  return <>{children}</>
 }
 
 export const NoMatch = () => (

--- a/react/src/Routes/Helpers.tsx
+++ b/react/src/Routes/Helpers.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useContext } from "react";
 
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Loader, Container, Dimmer } from "semantic-ui-react";
 
 import SimplePage from "Shared/SimplePage";
@@ -8,19 +8,19 @@ import { UserContainer } from "Shared/UserContainer";
 
 type RequireAuthProps = {
   children: ReactNode;
-  redirectTo: string;
 };
 
 // check the user is logged in, and redirect to login screen if still not auth'd
-export function RequireAuth({ children, redirectTo }: RequireAuthProps) {
+export const RequireAuth = ({ children }: RequireAuthProps) => {
   const { user, userLoading } = useContext(UserContainer);
+  const { pathname } = useLocation();
 
   if (userLoading) {
     return <BigLoader />;
   }
 
   if (!user.id) {
-    return <Navigate to={redirectTo} replace />;
+    return <Navigate to='/login' state={{from: pathname}} replace />;
   }
 
   return <>{children}</>

--- a/react/src/Routes/LogIn/LogIn.tsx
+++ b/react/src/Routes/LogIn/LogIn.tsx
@@ -1,14 +1,17 @@
-import React from 'react'
+import { useContext } from 'react'
 
 import { Link } from 'react-router-dom'
 import { Segment } from 'semantic-ui-react'
 
 import SimplePage from 'Shared/SimplePage'
+import { UserContainer } from 'Shared/UserContainer'
 
 import LogInForm from './LogInForm'
 
-const LogIn = () => (
-  <SimplePage title='Log In to your account' centered>
+const LogIn = () =>{ 
+  const { userLoading } = useContext(UserContainer)
+  return (
+  <SimplePage title='Log In to your account' centered loading={userLoading}>
     <Segment.Group>
       <Segment>
         <LogInForm />
@@ -19,6 +22,6 @@ const LogIn = () => (
       </Segment>
     </Segment.Group>
   </SimplePage>
-);
+);}
 
 export default LogIn;

--- a/react/src/Routes/LogIn/LogInForm.tsx
+++ b/react/src/Routes/LogIn/LogInForm.tsx
@@ -16,10 +16,9 @@ const LogInForm = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if(!user.id){
-      return
+    if (user.id) {
+      navigate("/posts", { replace: true})
     }
-    navigate("/posts", { replace: true})
   }, [user, navigate])
 
   const handleSubmit = useCallback(() => {

--- a/react/src/Routes/LogIn/LogInForm.tsx
+++ b/react/src/Routes/LogIn/LogInForm.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useContext } from 'react'
+import { useEffect, useCallback, useContext } from 'react'
 
-import { Redirect, useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from "react-router-dom";
 import { Form, Button, Message } from 'semantic-ui-react'
 
 import API from 'Api'
@@ -9,22 +9,29 @@ import { User } from 'Shared/Models'
 import { UserContainer } from 'Shared/UserContainer'
 
 const LogInForm = () => {
-  const location = useLocation<{ from: string }>()
+  const location = useLocation()
   const { user, setUser } = useContext(UserContainer)
   const [loading, error, run] = useRequest({} as User)
   const { fields, handleChange, setFields } = useFields({} as User)
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if(!user.id){
+      return
+    }
+    navigate("/posts", { replace: true})
+  }, [user, navigate])
 
   const handleSubmit = useCallback(() => {
     run(API.login(fields), user => {
-      setUser(user);
-      setFields({} as User)
+      if (user.id) {
+        setUser(user);
+        setFields({} as User)
+        const { from } = location.state || { from: { pathname: "/posts" } };
+        navigate(from);
+      }
     });
-  }, [run, fields, setFields, setUser])
-
-  if (user.id && user.id > 0 && !loading) {
-    const { from } = location.state || { from: { pathname: '/posts' } };
-    return <Redirect to={from} />;
-  }
+  }, [run, fields, setFields, setUser, navigate, location.state])
 
   const { email, pass } = fields;
 

--- a/react/src/Routes/Posts/PostForm.tsx
+++ b/react/src/Routes/Posts/PostForm.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import { useEffect, useCallback } from 'react'
 
-import { useParams } from 'react-router'
-import { Redirect } from 'react-router'
+import { useParams, useNavigate } from "react-router-dom";
 import { Form, Message, Button } from 'semantic-ui-react'
 
 import API from 'Api'
@@ -14,7 +13,7 @@ const PostForm = () => {
   const postID = Number(params.id);
   const [loading, error, run] = useRequest({} as Post)
   const {fields, handleChange, setFields} = useFields({} as Post)
-  const [redirectTo, setRedirectTo] = useState('');
+  const navigate = useNavigate();
 
   // if we have a post ID, fetch it
   useEffect(() => {
@@ -28,20 +27,18 @@ const PostForm = () => {
   // handlers
   const handleSubmit = useCallback(() => {
     const action = postID ? API.updatePost(fields) : API.createPost(fields);
-    run(action, () => {
-      setRedirectTo('/posts')
+    run(action, (data) => {
+      navigate(`/post/${data.id}`);
     })
-  }, [postID, fields, run])
+  }, [postID, fields, run, navigate])
 
   const handleDelete = useCallback(() => {
     run(API.deletePost(postID), () => {
-      setRedirectTo('/posts')
+      navigate('/posts')
     })
-  }, [run, postID])
+  }, [run, postID, navigate])
 
-  if (redirectTo) {
-    return <Redirect to={redirectTo} />
-  }
+  
 
   const { id, title, body } = fields;
 

--- a/react/src/Routes/Reset/CheckReset.tsx
+++ b/react/src/Routes/Reset/CheckReset.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useContext } from 'react'
+import { useEffect, useContext } from 'react'
 
-import { useParams } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { useNavigate, useParams } from "react-router-dom";
 
 import API from 'Api'
 import { useRequest } from 'Shared/Hooks';
@@ -12,22 +11,24 @@ import { UserContainer } from 'Shared/UserContainer'
 const CheckReset = () => {
   const { code } = useParams<{ code: string }>();
   const [loading, error, run] = useRequest<User>({} as User)
-  const [redirect, setRedirect] = useState('/posts')
-  const { user, userLoading, setUser } = useContext(UserContainer)
+  const { userLoading, setUser } = useContext(UserContainer)
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!userLoading) {
       // wait until defailt whoami returns before attempting reset
-      run(API.checkReset(code), user => {
-        setRedirect('/account/password');
-        setUser(user);
+      run(API.checkReset(code!), user => {
+        debugger
+        if (user.id) {
+          navigate("/account/password");
+          setUser(user);
+          return 
+        }
+        debugger
+        navigate("/posts");
       });
     }
-  }, [run, userLoading, setUser, setRedirect, code])
-
-  if (user.id && user.id > 0 && redirect) {
-    return <Redirect to={redirect} />
-  }
+  }, [run, userLoading, setUser, code, navigate])
 
   return (
     <SimplePage title='Logging you in...' loading={userLoading || loading} error={error} centered />

--- a/react/src/Routes/Reset/CheckReset.tsx
+++ b/react/src/Routes/Reset/CheckReset.tsx
@@ -18,13 +18,11 @@ const CheckReset = () => {
     if (!userLoading) {
       // wait until defailt whoami returns before attempting reset
       run(API.checkReset(code!), user => {
-        debugger
         if (user.id) {
           navigate("/account/password");
           setUser(user);
           return 
         }
-        debugger
         navigate("/posts");
       });
     }

--- a/react/src/Routes/Routes.tsx
+++ b/react/src/Routes/Routes.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Switch, Route } from 'react-router-dom'
 
 import ChangePassword from 'Routes/Account/ChangePassword'
-import { PrivateRoute, NoMatch } from 'Routes/Helpers'
+import { NoMatch, RequireAuth } from "Routes/Helpers";
 import Home from 'Routes/Home/Home'
 import LogIn from 'Routes/LogIn/LogIn'
 import Post from 'Routes/Posts/Post'
@@ -22,11 +22,55 @@ const Routes = () => (
     <Route exact path="/reset" component={Reset}/>
     <Route exact path="/reset/:code" component={CheckReset}/>
     <Route exact path="/verify/:code" component={Verify}/>
-    <PrivateRoute exact path="/account/password" component={ChangePassword}/>
-    <PrivateRoute exact path="/posts" component={Posts}/>
-    <PrivateRoute exact path="/post/create" component={PostForm}/>
-    <PrivateRoute exact path="/post/:id/edit" component={PostForm}/>
-    <PrivateRoute exact path="/post/:id" component={Post}/>
+    
+    {/* crud post routes */}
+    <Route
+        exact
+        path="/account/password"
+        render={() => (
+          <RequireAuth redirectTo="/login">
+            <ChangePassword />
+          </RequireAuth>
+        )}
+      />
+    <Route
+      exact
+      path="/posts"
+      render={() => {
+        return (
+          <RequireAuth redirectTo="/login">
+            <Posts />
+          </RequireAuth>
+        );
+      }}
+    />
+    <Route
+      exact
+      path="/post/create"
+      render={() => (
+        <RequireAuth redirectTo="/login">
+          <PostForm />
+        </RequireAuth>
+      )}
+    />
+    <Route
+      exact
+      path="/post/:id/edit"
+      render={() => (
+        <RequireAuth redirectTo="/login">
+          <PostForm />
+        </RequireAuth>
+      )}
+    />
+    <Route
+      exact
+      path="/post/:id"
+      render={() => (
+        <RequireAuth redirectTo="/login">
+          <Post />
+        </RequireAuth>
+      )}
+    />
     <Route component={NoMatch} />
   </Switch>
 )

--- a/react/src/Routes/Routes.tsx
+++ b/react/src/Routes/Routes.tsx
@@ -1,6 +1,4 @@
-import React from 'react'
-
-import { Switch, Route } from 'react-router-dom'
+import { Routes as ReactRouterRoutes, Route } from "react-router-dom";
 
 import ChangePassword from 'Routes/Account/ChangePassword'
 import { NoMatch, RequireAuth } from "Routes/Helpers";
@@ -15,64 +13,57 @@ import SignUp from 'Routes/SignUp/SignUp'
 import Verify from 'Routes/Verify/Verify'
 
 const Routes = () => (
-  <Switch>
-    <Route exact path="/" component={Home} />
-    <Route exact path="/signup" component={SignUp}/>
-    <Route exact path="/login" component={LogIn}/>
-    <Route exact path="/reset" component={Reset}/>
-    <Route exact path="/reset/:code" component={CheckReset}/>
-    <Route exact path="/verify/:code" component={Verify}/>
+  <ReactRouterRoutes>
+    <Route path="/" element={<Home />} />
+    <Route path="/signup" element={<SignUp />}/>
+    <Route path="/login" element={<LogIn />}/>
+    <Route path="/reset" element={<Reset />}/>
+    <Route path="/reset/:code" element={<CheckReset />}/>
+    <Route path="/verify/:code" element={<Verify />}/>
     
     {/* crud post routes */}
     <Route
-        exact
-        path="/account/password"
-        render={() => (
-          <RequireAuth redirectTo="/login">
-            <ChangePassword />
-          </RequireAuth>
-        )}
+      path="/account/password"
+      element={
+        <RequireAuth redirectTo="/login">
+          <ChangePassword />
+        </RequireAuth>
+      }
       />
     <Route
-      exact
       path="/posts"
-      render={() => {
-        return (
-          <RequireAuth redirectTo="/login">
-            <Posts />
-          </RequireAuth>
-        );
-      }}
+      element={
+        <RequireAuth redirectTo="/login">
+          <Posts />
+        </RequireAuth>
+      }
     />
     <Route
-      exact
       path="/post/create"
-      render={() => (
+      element={
         <RequireAuth redirectTo="/login">
           <PostForm />
         </RequireAuth>
-      )}
+      }
     />
     <Route
-      exact
       path="/post/:id/edit"
-      render={() => (
+      element={
         <RequireAuth redirectTo="/login">
           <PostForm />
         </RequireAuth>
-      )}
+      }
     />
     <Route
-      exact
       path="/post/:id"
-      render={() => (
+      element={
         <RequireAuth redirectTo="/login">
           <Post />
         </RequireAuth>
-      )}
+      }
     />
-    <Route component={NoMatch} />
-  </Switch>
+    <Route element={<NoMatch />} />
+  </ReactRouterRoutes>
 )
 
 export default Routes;

--- a/react/src/Routes/Routes.tsx
+++ b/react/src/Routes/Routes.tsx
@@ -25,7 +25,7 @@ const Routes = () => (
     <Route
       path="/account/password"
       element={
-        <RequireAuth redirectTo="/login">
+        <RequireAuth>
           <ChangePassword />
         </RequireAuth>
       }
@@ -33,7 +33,7 @@ const Routes = () => (
     <Route
       path="/posts"
       element={
-        <RequireAuth redirectTo="/login">
+        <RequireAuth>
           <Posts />
         </RequireAuth>
       }
@@ -41,7 +41,7 @@ const Routes = () => (
     <Route
       path="/post/create"
       element={
-        <RequireAuth redirectTo="/login">
+        <RequireAuth>
           <PostForm />
         </RequireAuth>
       }
@@ -49,7 +49,7 @@ const Routes = () => (
     <Route
       path="/post/:id/edit"
       element={
-        <RequireAuth redirectTo="/login">
+        <RequireAuth>
           <PostForm />
         </RequireAuth>
       }
@@ -57,7 +57,7 @@ const Routes = () => (
     <Route
       path="/post/:id"
       element={
-        <RequireAuth redirectTo="/login">
+        <RequireAuth>
           <Post />
         </RequireAuth>
       }

--- a/react/src/Routes/Verify/Verify.tsx
+++ b/react/src/Routes/Verify/Verify.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useContext } from 'react'
+import { useEffect, useContext } from 'react'
 
-import { useParams } from 'react-router'
-import { Redirect } from 'react-router-dom'
+import { useNavigate, useParams } from "react-router-dom";
 import { Message } from 'semantic-ui-react'
 
 import API from 'Api'
@@ -13,25 +12,26 @@ import { UserContainer } from 'Shared/UserContainer'
 const Verify = () => {
   const { code } = useParams<{ code: string }>();
   const [loading, error, run, user] = useRequest<User>({} as User)
-  const [redirect, setRedirect] = useState(false)
   const { userLoading, setUser } = useContext(UserContainer)
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!userLoading) {
       // wait until default whoami (called within the UserContainer) returns 
       // before attempting reset, otherwise there is a race condition
+      if(!code){
+        navigate("/")
+        return
+      }
+
       run(API.verify({ code }), user => {
         setUser(user);
         setTimeout(() => {
-          setRedirect(true);
+          navigate("/posts")
         }, 2500);
       })
     }
-  }, [run, setUser, setRedirect, code, userLoading])
-
-  if (redirect) {
-    return <Redirect to="/posts" />
-  }
+  }, [run, setUser, code, userLoading, navigate])
 
   return (
     <SimplePage title='Account Verification' centered loading={loading} error={error}>


### PR DESCRIPTION
## Overview
Bumps react-router to v6. PR is divided into two commits. Migration guide [here](https://reactrouter.com/en/main/upgrading/v).

First commit [refactors custom routes](https://reactrouter.com/en/main/upgrading/v5#refactor-custom-routes).
Second commit performs the version bump.

## Notable Changes
- MenuLink component was deleted because NavLink by default adds an "active" class to the currently active NavLink.
- PrivateRoute was renamed to RequireAuth.


## Testing
I performed some manual tests. But in the absence of any automated tests, I'm not 100% confident, I covered all paths.